### PR TITLE
PR434 on PR436: Adds spaces in variables after {{ and before }}

### DIFF
--- a/iiab.yml
+++ b/iiab.yml
@@ -4,7 +4,7 @@
 
   vars_files:
   - vars/default_vars.yml
-  - vars/{{ ansible_local.local_facts.os_ver}}.yml
+  - vars/{{ ansible_local.local_facts.os_ver }}.yml
   - vars/local_vars.yml
   - /etc/iiab/config_vars.yml
 

--- a/roles/2-common/tasks/xo.yml
+++ b/roles/2-common/tasks/xo.yml
@@ -109,7 +109,7 @@
         state=absent
 
 - name: Download substitute software for i386 on FC18 XO1.5
-  get_url: url="{{ iiab_download_url }}/{{ item }}"  dest={{ downloads_dir}}/{{ item }}
+  get_url: url="{{ iiab_download_url }}/{{ item }}"  dest={{ downloads_dir }}/{{ item }}
   with_items:
      - hostapd_8188_i386
   when: wifi_id  ==  "tplink_WM725M" and xo_model == "XO-1.5"  and internet_available

--- a/roles/activity-server/tasks/main.yml
+++ b/roles/activity-server/tasks/main.yml
@@ -16,7 +16,7 @@
 # Wish synchronize worked, but it doesn't
 
 - name: Copy language templates
-  command: rsync -a {{iiab_dir}}/roles/activity-server/files/lang_templates /library/xs-activity-server/
+  command: rsync -a {{ iiab_dir }}/roles/activity-server/files/lang_templates /library/xs-activity-server/
 
 - name: Copy default index files
   copy: src={{ item }}

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: Get the Dokuwiki software
-  get_url: url="{{ iiab_download_url }}/{{ dokuwiki_version }}.tgz"  dest={{ downloads_dir}}/
+  get_url: url="{{ iiab_download_url }}/{{ dokuwiki_version }}.tgz"  dest={{ downloads_dir }}/
   when: internet_available
 
 - name: Copy it to permanent location /library

--- a/roles/elgg/templates/settings.php.j2
+++ b/roles/elgg/templates/settings.php.j2
@@ -35,21 +35,21 @@ if (!isset($CONFIG)) {
  *
  * @global string $CONFIG->dbuser
  */
-$CONFIG->dbuser = '{{dbuser}}';
+$CONFIG->dbuser = '{{ dbuser }}';
 
 /**
  * The database password
  *
  * @global string $CONFIG->dbpass
  */
-$CONFIG->dbpass = '{{dbpassword}}';
+$CONFIG->dbpass = '{{ dbpassword }}';
 
 /**
  * The database name
  *
  * @global string $CONFIG->dbname
  */
-$CONFIG->dbname = '{{dbname}}';
+$CONFIG->dbname = '{{ dbname }}';
 
 /**
  * The database host.
@@ -58,7 +58,7 @@ $CONFIG->dbname = '{{dbname}}';
  *
  * @global string $CONFIG->dbhost
  */
-$CONFIG->dbhost = '{{dbhost}}';
+$CONFIG->dbhost = '{{ dbhost }}';
 
 /**
  * The database prefix
@@ -69,7 +69,7 @@ $CONFIG->dbhost = '{{dbhost}}';
  *
  * @global string $CONFIG->dbprefix
  */
-$CONFIG->dbprefix = '{{dbprefix}}';
+$CONFIG->dbprefix = '{{ dbprefix }}';
 
 /**
  * Multiple database connections
@@ -130,17 +130,17 @@ $CONFIG->dbprefix = '{{dbprefix}}';
 /**
  * Cookie configuration
  *
- * Elgg uses 2 cookies: a PHP session cookie and an extended login cookie 
+ * Elgg uses 2 cookies: a PHP session cookie and an extended login cookie
  * (also called the remember me cookie). See the PHP manual for documentation on
  * each of these parameters. Possible options:
- * 
+ *
  *  - Set the session name to share the session across applications.
  *  - Set the path because Elgg is not installed in the root of the web directory.
  *  - Set the secure option to true if you only serve the site over HTTPS.
  *  - Set the expire option on the remember me cookie to change its lifetime
  *
  * To use, uncomment the appropriate sections below and update for your site.
- * 
+ *
  * @global array $CONFIG->cookies
  */
 // get the default parameters from php.ini
@@ -197,16 +197,16 @@ $CONFIG->min_password_length = 6;
 /**
  * This is an optional script used to override Elgg's default handling of
  * uncaught exceptions.
- * 
+ *
  * This should be an absolute file path to a php script that will be called
  * any time an uncaught exception is thrown.
- * 
+ *
  * The script will have access to the following variables as part of the scope
  * global $CONFIG
  * $exception - the unhandled exception
- * 
+ *
  * @warning - the database may not be available
- * 
+ *
  * @global string $CONFIG->exception_include
  */
 $CONFIG->exception_include = '';

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -65,9 +65,9 @@
   with_items:
     - { src: 'kalite-serve.service.j2', dest: '/etc/systemd/system/kalite-serve.service', mode: '0644'}
     - { src: 'kalite.sh.j2', dest: '/etc/profile.d/kalite.sh', mode: '0644'}
-    - { src: 'kalite.conf', dest: '/etc/{{ apache_config_dir}}', mode: '0644'}
+    - { src: 'kalite.conf', dest: '/etc/{{ apache_config_dir }}', mode: '0644'}
 
 - name: Create symlink to kalite bin file in path
   file: path=/usr/bin/kalite
-        src={{kalite_venv}}/bin/kalite
+        src={{ kalite_venv }}/bin/kalite
         state=link

--- a/roles/kiwix/templates/iiab-make-kiwix-lib
+++ b/roles/kiwix/templates/iiab-make-kiwix-lib
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-{{systemctl_program }} stop kiwix-serve
+{{ systemctl_program }} stop kiwix-serve
 /usr/bin/iiab-make-kiwix-lib.py
 /usr/bin/iiab-make-apache-config.py
 {{ systemctl_program }} start kiwix-serve

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -106,7 +106,7 @@
   become_user: postgres
 
 - name: Put a startup install script in place
-  template: dest={{moodle_base}}
+  template: dest={{ moodle_base }}
             src=moodle_installer
             mode=0755
 

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -53,7 +53,7 @@
 - name: set ssh port for avahi
   lineinfile: dest=/etc/avahi/services/ssh.service
               regexp='</port>$'
-              line='    <port>{{ssh_port}}</port>'
+              line='    <port>{{ ssh_port }}</port>'
               state=present
               backrefs=yes
 

--- a/roles/network/tasks/static.yml
+++ b/roles/network/tasks/static.yml
@@ -14,6 +14,6 @@
 
 - name: use upstream nameserver until named is installed
   lineinfile: dest=/etc/resolv.conf
-              line='nameserver {{wan_nameserver}}'
+              line='nameserver {{ wan_nameserver }}'
               create=yes
               state=present

--- a/roles/network/templates/avahi/schoolserver.service
+++ b/roles/network/templates/avahi/schoolserver.service
@@ -4,6 +4,6 @@
 <name replace-wildcards="yes">MGMT console at %h </name>
 <service>
 <type>_https._tcp</type>
-<port>{{gui_port}}</port>
+<port>{{ gui_port }}</port>
 </service>
 </service-group>

--- a/roles/network/templates/dhcp/dhcpd-env.j2
+++ b/roles/network/templates/dhcp/dhcpd-env.j2
@@ -1,8 +1,7 @@
 ## XS Config override
 ##
 ## This file has an ".in" template - for details see
-##  see /usr/share/doc/xs-config-<version>/README 
+##  see /usr/share/doc/xs-config-<version>/README
 #
 # Point dhcpd to the XS-specific config
-DHCPDARGS='-cf /etc/dhcpd-iiab.conf {{iiab_lan_iface}}'
-
+DHCPDARGS='-cf /etc/dhcpd-iiab.conf {{ iiab_lan_iface }}'

--- a/roles/network/templates/gateway/iiab-gen-iptables
+++ b/roles/network/templates/gateway/iiab-gen-iptables
@@ -16,10 +16,10 @@ $IPTABLES -t nat -F
 $IPTABLES -X
 
 # first match wins
-# Always accept loopback traffic 
+# Always accept loopback traffic
 $IPTABLES -A INPUT -i lo -j ACCEPT
 
-# Always drop rpc 
+# Always drop rpc
 $IPTABLES -A INPUT -p tcp --dport 111 -j DROP
 $IPTABLES -A INPUT -p udp --dport 111 -j DROP
 # mysql
@@ -73,10 +73,10 @@ clear_fw
 $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 $IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
 
-# Allow mDNS 
+# Allow mDNS
 $IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
-#when run as gateway 
+#when run as gateway
 $IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
 
 if [ "$gui_wan" == "True" ]; then
@@ -96,9 +96,9 @@ fi
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 #Block https traffic except if directed at server
-if [  "$gw_block_https" == "True" ]; then    
+if [  "$gw_block_https" == "True" ]; then
     $IPTABLES -A FORWARD -p tcp ! -d 172.18.96.1 --dport 443 -j DROP
-fi   
+fi
 
 # Allow outgoing connections from the LAN side.
 $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
@@ -108,8 +108,8 @@ $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
 $IPTABLES -A INPUT -i $wan -j DROP
 
 if [ "$block_DNS" == "True" ];then
-    $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
-    $IPTABLES -t nat -A PREROUTING -i $lan -p udp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+    $IPTABLES -t nat -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
+    $IPTABLES -t nat -A PREROUTING -i $lan -p udp --dport 53 ! -d {{ lan_ip }} -j DNAT --to {{ lan_ip }}:53
 fi
 
 if [ -f /etc/sysconfig/xs_httpcache_on ]; then

--- a/roles/network/templates/network/br0.j2
+++ b/roles/network/templates/network/br0.j2
@@ -3,7 +3,7 @@
 
 # we always want the wireless to be configured (and under bridge)
 auto {{ discovered_wireless_iface }}
-iface {{discovered_wireless_iface }} inet manual
+iface {{ discovered_wireless_iface }} inet manual
    pre-up   ifconfig $IFACE up
    pre-down ifconfig $IFACE down
 
@@ -13,7 +13,7 @@ auto {{ discovered_wan_iface }}
 {% if gui_static_wan == false %}
 iface {{ discovered_wan_iface }} inet dhcp
     pre-up ip link set br0 down && brctl delbr br0
-{% else %} # gui_static_wan_ip is set 
+{% else %} # gui_static_wan_ip is set
 iface {{ discovered_wan_iface }} inet static
 #    pre-up ip link set br0 down && brctl delbr br0
     address {{ gui_static_wan_ip }}
@@ -25,7 +25,7 @@ iface {{ discovered_wan_iface }} inet static
 #################   GATEWAY   #########################
 auto br0
 iface br0 inet static
-    bridge_ports {{ discovered_wireless_iface }} 
+    bridge_ports {{ discovered_wireless_iface }}
     address {{ lan_ip }}
     netmask {{ lan_netmask }}
     dns-nameservers {{ lan_ip }}
@@ -36,7 +36,7 @@ allow-hotplug {{ discovered_wan_iface }}
 iface {{ discovered_wan_iface }} inet manual
    pre-up   ifconfig $IFACE up
    pre-down ifconfig $IFACE down
-{% else %} # gui_static_wan_ip is set 
+{% else %} # gui_static_wan_ip is set
 iface {{ discovered_wan_iface }} inet static
     address {{ gui_static_wan_ip }}
     netmask {{ gui_static_wan_netmask }}
@@ -58,4 +58,3 @@ iface br0 inet static
     dns-search {{ iiab_domain }}
     post-up systemctl restart dhcpd && systemctl restart hostapd
 {% endif %}
-

--- a/roles/network/templates/network/iiab.j2
+++ b/roles/network/templates/network/iiab.j2
@@ -6,7 +6,7 @@
 
 {% if discovered_wireless_iface != 'none' %}
 auto {{ discovered_wireless_iface }}
-iface {{discovered_wireless_iface }} inet manual
+iface {{ discovered_wireless_iface }} inet manual
 {% endif %}
 
 {% if iiab_network_mode == "Appliance"  %}
@@ -45,4 +45,3 @@ iface br0 inet static
     dns-search {{ iiab_domain }}
     post-up systemctl restart dhcpd && systemctl restart hostapd
 {% endif %}
-

--- a/roles/nextcloud/templates/nextcloud.conf.j2
+++ b/roles/nextcloud/templates/nextcloud.conf.j2
@@ -1,4 +1,4 @@
-Alias {{ nextcloud_url }} {{ nextcloud_prefix}}/nextcloud
+Alias {{ nextcloud_url }} {{ nextcloud_prefix }}/nextcloud
 
 <Directory {{ nextcloud_prefix }}/nextcloud/>
     Options -Indexes
@@ -6,7 +6,7 @@ Alias {{ nextcloud_url }} {{ nextcloud_prefix}}/nextcloud
     <IfModule mod_authz_core.c>
     # Apache 2.4
     Require host localhost
-    Require ip 127.0.0.1 {{lan_ip}}/{{lan_netmask}} {{ nextcloud_required_ip }}
+    Require ip 127.0.0.1 {{ lan_ip }}/{{ lan_netmask }} {{ nextcloud_required_ip }}
     </IfModule>
     <IfModule !mod_authz_core.c>
     # Apache 2.2

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Create data directory library
   file: path={{ item }}
         mode=0750
-        owner={{ apache_user}}
+        owner={{ apache_user }}
         group=apache
         state=directory
   with_items:

--- a/roles/owncloud/templates/owncloud.conf.j2
+++ b/roles/owncloud/templates/owncloud.conf.j2
@@ -1,4 +1,4 @@
-Alias {{ owncloud_url }} {{ owncloud_prefix}}/owncloud
+Alias {{ owncloud_url }} {{ owncloud_prefix }}/owncloud
 
 <Directory {{ owncloud_prefix }}/owncloud/>
     Options -Indexes
@@ -6,7 +6,7 @@ Alias {{ owncloud_url }} {{ owncloud_prefix}}/owncloud
     <IfModule mod_authz_core.c>
     # Apache 2.4
     Require host localhost
-    Require ip 127.0.0.1 {{lan_ip}}/{{lan_netmask}} {{ owncloud_required_ip }}
+    Require ip 127.0.0.1 {{ lan_ip }}/{{ lan_netmask }} {{ owncloud_required_ip }}
     </IfModule>
     <IfModule !mod_authz_core.c>
     # Apache 2.2

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -1,5 +1,5 @@
     - name: Get the phpmyadmin software
-      get_url: url="{{ iiab_download_url }}/{{ phpMyAdmin }}"  dest="{{ downloads_dir}}/phpMyAdmin.zip"
+      get_url: url="{{ iiab_download_url }}/{{ phpMyAdmin }}"  dest="{{ downloads_dir }}/phpMyAdmin.zip"
       when: internet_available
 
     - name: Copy it to permanent location /opt

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: Get the WordPress software
-  get_url: url="{{ wordpress_download_base_url }}/{{ wordpress_src }}"  dest={{ downloads_dir}}/
+  get_url: url="{{ wordpress_download_base_url }}/{{ wordpress_src }}"  dest={{ downloads_dir }}/
   register: wp_download_output
   when: internet_available
 

--- a/roles/xovis/tasks/main.yml
+++ b/roles/xovis/tasks/main.yml
@@ -62,7 +62,7 @@
   when: xovis_enabled
 
 - name: Check if db exists
-  shell: "kanso listdb | grep {{xovis_db_name }}"
+  shell: "kanso listdb | grep {{ xovis_db_name }}"
   register: found_db
   ignore_errors: yes
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -46,7 +46,7 @@ lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
 # Read https://github.com/iiab/iiab/wiki/IIAB-Networking
-# Also readable offline @ http://box/info/IIAB-Networking.html 
+# Also readable offline @ http://box/info/IIAB-Networking.html
 
 # Gateway mode
 iiab_lan_enabled: True
@@ -272,7 +272,7 @@ rachel_install: False
 rachel_enabled: False
 rachel_content_found: False
 #rachel_url: /rachel
-rachel_doc_root: "{{ doc_root}}/modules"
+rachel_doc_root: "{{ doc_root }}/modules"
 
 # Kiwix-serve
 kiwix_install: True


### PR DESCRIPTION
Fixes various warnings in Travis CI 

[EXTRA0001] Variables should have spaces after {{ and before }}